### PR TITLE
Optimization of fireteam.sqf

### DIFF
--- a/TEAM_40[BC]Fireteams_v24.Altis/scripts/fireteam.sqf
+++ b/TEAM_40[BC]Fireteams_v24.Altis/scripts/fireteam.sqf
@@ -174,11 +174,13 @@ moveTriggersAndMarkers = {
             _objHold setMarkerBrush "SolidBorder";
             _objHold setMarkerColor "ColorUNKNOWN";
             
+            _colorSeize = ["blueSeize", "redSeize", "greenSeize", "purpleSeize"];
             {
                 _x setMarkerPos _objPos;
                 _x setMarkerSize [sizeOfObjHold, sizeOfObjHold];
                 _x setMarkerAlpha 0;
-            } forEach ["blueSeize", "redSeize", "greenSeize", "purpleSeize"];
+                false
+            } count (_colorSeize);
         };
     };
     


### PR DESCRIPTION
Removed forEach and used count instead as count is faster than forEach. There is no need to use forEach as the current form of the script does not require the forEach index variable so count should be used instead since it's faster.