### PR TITLE
Fixed potential issue with PFH's in bcInit.sqf

### DIFF
--- a/TEAM_40[BC]Fireteams_v24.Altis/f/bcInit.sqf
+++ b/TEAM_40[BC]Fireteams_v24.Altis/f/bcInit.sqf
@@ -46,7 +46,7 @@ disableRemoteSensors true;
 
 //====================================================================================================
 //Pre Briefing Client Scripts
-if (!isDedicated) then {
+if (!isDedicated or hasInterface) then {
     bc_core_showTags = [BC_fnc_core_showTags, 0, []] call CBA_fnc_addPerFrameHandler;
     bc_radHandle1 = [BC_fnc_radio_waitGear, 0.1, []] call CBA_fnc_addPerFrameHandler;
     bc_end_clientWait = [BC_fnc_end_clientWait, 5, []] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
Could be a potential issue with PFH's executing on headless clients. There is no need to have headless clients run PFH's. This will eliminate that potential issue.

 - Changed '!isDedicated' to '!isDedicated or hasInterface'

Headless clients and dedicated servers with or without an interface will not pass this condition as true