### PR TITLE
Updates and optimizations to fn_core_showTags.sqf

### DIFF
--- a/TEAM_40[BC]Fireteams_v24.Altis/f/core/fn_core_showTags.sqf
+++ b/TEAM_40[BC]Fireteams_v24.Altis/f/core/fn_core_showTags.sqf
@@ -1,15 +1,9 @@
 _target = cursorObject;
-if (!isNull _target) then {
-    if (player distance _target < 15) then {
-        if (player == vehicle player) then {
-            if (_target isKindOf "Man") then {
-                if (side _target == side player)then {
-                    if (alive _target) then {
-                        _nameString = format ["<t size='0.375' shadow='2' font='TahomaB' color='#ba9d00'>%2<br/><t size='0.5'>%1</t></t>",name _target,groupID (group _target)];
-                        [_nameString,0,1,0,0,0,4] spawn bis_fnc_dynamicText;
-                    };
-                };
-            };
-        };
-    };
+if (isNull _target) exitWith {false};
+_return = false;
+_return = if ((player distance _target < 15) && (isNull objectParent player) && (_target isKindOf "Man") && (side _target == side player) && (alive _target)) then {
+    _nameString = format ["<t size='0.375' shadow='2' font='TahomaB' color='#ba9d00'>%2<br/><t size='0.5'>%1</t></t>",name _target,groupID (group _target)];
+    [_nameString,0,1,0,0,0,4] spawn BIS_fnc_dynamicText;
+    true
 };
+_return


### PR DESCRIPTION
Updated with new commands and for optimization

 - Added a check at the very top to see if a player's weapon cursor is pointing at an object. If it returns false, then the function will exit, which then the PFH will exit and make sure that no unnecessary code is ran after the PFH exits for that frame. There is no need to run unnecessary code after the first check fails.
 - Changed (player == vehicle player) to (isNull objectParent player), this way is faster